### PR TITLE
Add links to Footer and Header and Make the header sticky on privacy

### DIFF
--- a/imprint.html
+++ b/imprint.html
@@ -31,7 +31,7 @@
       loadComponents("footer", "src/sections/footer.html");
     };
   </script>
-  <body class="bg-background text-darkgreen font-sans relative">
+  <body class="bg-background text-darkgreen relative">
     <div class="text-sm sticky top-0" id="header"></div>
     <main
       class="grid grid-cols-1 md:grid-cols-12 lg:grid-cols-9 md:gap-x-5 lg:gap-6 mt-23 px-4.5 md:pl-14 md:pr-16.25 lg:px-49.75 text-2xl text-greenText"
@@ -97,10 +97,10 @@
           <ul
             class="flex gap-x-4 md:justify-between lg:gap-x-12 md:flex-row-reverse lg:flex-row-reverse lg:flex-wrap"
           >
-            <li class="lg:order-4"><a href="">Datenschutz</a></li>
-            <li class="lg:order-1"><a href="/imprint.html"">Impressum</a></li>
-            <li class="md:order-4 lg:order-3"><a href="#">LinkedIn</a></li>
-            <li class="md:order-3 lg:order-2"><a href="#">Instagram</a></li>
+            <li class="lg:order-4"><a href="/privacy">Data privacy</a></li>
+            <li class="lg:order-1"><a href="/imprint">Imprint</a></li>
+            <li class="md:order-4 lg:order-3"><a href="https://www.linkedin.com/company/agentur-baumeister/" target="_blank">LinkedIn</a></li>
+            <li class="md:order-3 lg:order-2"><a href="https://www.instagram.com/baumeister_agency?igsh=MWw3bm9tbnpkMTlzNQ%3D%3D" target="_blank">Instagram</a></li>
           </ul>
         </nav>
       </div>

--- a/imprint.html
+++ b/imprint.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="dist/output.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="shortcut icon" href="/public/images/favicon.ico" >
     <link
       href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap"
       rel="stylesheet"

--- a/privacy.html
+++ b/privacy.html
@@ -3,7 +3,6 @@
 
 <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Baumeister | Privacy Policy</title>
     <link rel="stylesheet" href="dist/output.css" />

--- a/privacy.html
+++ b/privacy.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Baumeister | Privacy Policy</title>
     <link rel="stylesheet" href="dist/output.css" />
+    <link rel="shortcut icon" href="/public/images/favicon.ico" >
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet" />
 
     <script>

--- a/privacy.html
+++ b/privacy.html
@@ -26,8 +26,8 @@
         };
     </script>
 </head>
-<body class="text-green">
-    <div id="header"></div>
+<body class="text-green relative bg-background">
+    <div id="header" class="sticky top-0 z-30"></div>
     <div id="privacy-main"></div>
     <div id="footer"></div>
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Privacy Policy</title>
+    <title>Baumeister | Privacy Policy</title>
     <link rel="stylesheet" href="dist/output.css" />
     <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@100..900&display=swap" rel="stylesheet" />
 

--- a/src/sections/footer.html
+++ b/src/sections/footer.html
@@ -22,10 +22,10 @@
       <ul
         class="flex gap-x-4 md:justify-between lg:gap-x-44 md:flex-row-reverse lg:flex-row-reverse lg:flex-wrap"
       >
-        <li class="lg:order-4"><a href="#">Datenschutz</a></li>
-        <li class="lg:order-1"><a href="#">Impressum</a></li>
-        <li class="md:order-4 lg:order-3"><a href="#">LinkedIn</a></li>
-        <li class="md:order-3 lg:order-2"><a href="#">Instagram</a></li>
+        <li class="lg:order-4"><a href="/privacy">Data privacy</a></li>
+        <li class="lg:order-1"><a href="/imprint">Imprint</a></li>
+        <li class="md:order-4 lg:order-3"><a href="https://www.linkedin.com/company/agentur-baumeister/" target="_blank">LinkedIn</a></li>
+        <li class="md:order-3 lg:order-2"><a href="https://www.instagram.com/baumeister_agency?igsh=MWw3bm9tbnpkMTlzNQ%3D%3D" target="_blank">Instagram</a></li>
       </ul>
     </nav>
   </div>

--- a/src/sections/header.html
+++ b/src/sections/header.html
@@ -11,10 +11,10 @@
     </div>
     <nav class="hidden lg:flex flex-col leading-none text-2xl items-end">
         <ul>
-            <li><a href="#about">About</a></li>
-            <li><a href="#services">Services</a></li>
-            <li><a href="#references">References</a></li>
-            <li><a href="#footer">Contact</a></li>
+            <li><a href="/#about">About</a></li>
+            <li><a href="/#services">Services</a></li>
+            <li><a href="/#references">References</a></li>
+            <li><a href="/#footer">Contact</a></li>
         </ul>
     </nav>
     <div class="cursor-pointer h-12 w-16 lg:hidden">
@@ -43,10 +43,10 @@
         </div>
       </div>
       <ul id="menu-links" class="font-semibold flex flex-col gap-10 md:gap-12 px-6 text-darkgreen text-center text-medium md:text-5xl mt-22.5 md:mt-30 md:-translate-y-20">
-        <li><a href="#about">About</a></li>
-        <li><a href="#services">Services</a></li>
-        <li><a href="#references">References</a></li>
-        <li><a href="#footer">Contact</a></li>
+        <li><a href="/#about">About</a></li>
+        <li><a href="/#services">Services</a></li>
+        <li><a href="/#references">References</a></li>
+        <li><a href="/#footer">Contact</a></li>
       </ul>
       <img src="/public/images/hero.svg" class="absolute lg:hidden top-114 -z-40 w-full md:top-104">
     </div>


### PR DESCRIPTION
### What does this PR do?

- This PR correctly adds navigation links in the footer to privacy and imprint pages
- It renames the privacy and imprint links from german to english
- It also makes the header sticky on the privacy page

### Description of the PR?

- Please see above

### Any background context you want to provide?

- N/A 

### What are the relevant Trello cards?

- None

### Screenshots (if appropriate)

- N/A
- This is a purely code change, it does not affect the visible text,

![image](https://github.com/user-attachments/assets/2e736ca7-89a1-40ee-b974-3dc6adfb2ae9)

### How to test?

- Pull and checkout the `ft/fix-links` branch, then run `npx serve` and `npm run dev` in another terminal